### PR TITLE
fix: use dns filters add instead of enable for first-time activation

### DIFF
--- a/adguard_tray/cli.py
+++ b/adguard_tray/cli.py
@@ -483,7 +483,7 @@ class AdGuardCLI:
         return False, msg
 
     def add_dns_filter(self, filter_id: str) -> tuple[bool, str]:
-        code, out, err = _run([self.BINARY, "dns", "filters", "add", filter_id], timeout=15)
+        code, out, err = _run([self.BINARY, "dns", "filters", "add", str(filter_id)], timeout=15)
         if code == 0 and not _is_cli_failure(out):
             return True, out or _t("DNS filter added")
         msg = err or out or _t("Could not add DNS filter")

--- a/adguard_tray/dns_filters_tab.py
+++ b/adguard_tray/dns_filters_tab.py
@@ -52,16 +52,16 @@ class _LoadWorker(QThread):
 class _ToggleWorker(QThread):
     done = pyqtSignal(bool, str, int, bool)
 
-    def __init__(self, cli, fid, enable):
+    def __init__(self, cli, fid, add):
         super().__init__()
         self.cli = cli
         self.fid = fid
-        self.enable = enable
+        self.add = add
 
     def run(self):
-        fn = self.cli.enable_dns_filter if self.enable else self.cli.disable_dns_filter
-        ok, msg = fn(self.fid)
-        self.done.emit(ok, msg, self.fid, self.enable)
+        fn = self.cli.add_dns_filter if self.add else self.cli.disable_dns_filter
+        ok, msg = fn(str(self.fid))
+        self.done.emit(ok, msg, self.fid, self.add)
 
 
 class _RemoveWorker(QThread):
@@ -248,10 +248,10 @@ class DnsFiltersTab(QWidget):
         fid = item.data(0, Qt.ItemDataRole.UserRole)
         if fid is None:
             return
-        enable = item.checkState(0) == Qt.CheckState.Checked
+        add = item.checkState(0) == Qt.CheckState.Checked
         self._set_busy(True)
         self.tree.itemChanged.disconnect(self._on_item_changed)
-        w = _ToggleWorker(self.cli, fid, enable)
+        w = _ToggleWorker(self.cli, fid, add)
         w.done.connect(self._on_toggle_done)
         w.finished.connect(lambda: self._workers.remove(w) if w in self._workers else None)
         self._workers.append(w)


### PR DESCRIPTION
When a user enables a DNS filter checkbox for the first time in adguard-tray, the application was calling enable_dns_filter() which maps to adguard-cli dns filters enable. This fails because the AdGuard CLI requires the filter to be added first using dns filters add before it can be enabled.

## Fix
Changed the toggle to use add_dns_filter() when enabling, which calls adguard-cli dns filters add - this adds AND enables the filter in one step.

Also fixed a missing str() conversion bug in the add_dns_filter function.

## Testing
Verified manually:
- Check a DNS filter that was never added - now works correctly
- Disable and re-enable existing filter - still works